### PR TITLE
Added virtual destructor -- works now on my mac

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -171,6 +171,7 @@ public:
 	virtual bool propagate(Output* output) const = 0;
 	virtual bool on_boundary(int x, int y) const = 0;
 	virtual Image image(const Output& output) const = 0;
+	virtual ~Model()  { }
 };
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Hi Emil. Thanks for your code, it worked for me with just one change. 

On my mac, llvm was complaining about the virtual destructor and also the program was crashing. Adding the destructor actually fixed both.
